### PR TITLE
Fixing spelling issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ let { xs, sm, md, lg } = useBreakpoints({
 });
 ```
 
-### useCurrentWitdh usage
+### useCurrentWidth usage
 ```js
 // returns current width, gets updated at rezise
-let width = useCurrentWitdh();
+let width = useCurrentWidth();
 });
 ```
 
 ### Example
 ```jsx
 import React from 'react';
-import { useBreakpoints, useCurrentWitdh } from 'react-breakpoints-hook';
+import { useBreakpoints, useCurrentWidth } from 'react-breakpoints-hook';
 
 
 const App = () => {
-  let width = useCurrentWitdh();
+  let width = useCurrentWidth();
   let { xs, sm, md, lg } = useBreakpoints({
     xs: {min: 0, max: 360},
     sm: {min: 361, max: 960},


### PR DESCRIPTION
Width was spelt incorrectly in a bunch of places